### PR TITLE
fix: resolve build failure on older GCC versions in `run.ps1`

### DIFF
--- a/scripts/run.ps1
+++ b/scripts/run.ps1
@@ -26,7 +26,23 @@ switch ($extension) {
     }
     ".cpp" {
         Write-Host "Compiling C++..."
-        g++ $file -O3 -Wall -Wextra -std=c++23 -o "$filename.exe"
+        try {
+            $gccVerStr = g++ -dumpversion   
+            $majorVer = [int]($gccVerStr -split '\.')[0]
+        } catch {
+            $majorVer = 0 
+        }
+        if ($majorVer -ge 13) {
+            $stdFlag = "-std=c++23"
+        } elseif ($majorVer -ge 11) {
+            $stdFlag = "-std=c++20"
+        } elseif ($majorVer -ge 8) {
+            $stdFlag = "-std=c++17"
+        } else {
+            $stdFlag = "-std=c++14" # For very old compilers
+        }
+        Write-Host "Detected GCC v$majorVer. Using flag: $stdFlag"
+        g++ $file -O3 -Wall -Wextra $stdFlag -o "$filename.exe"
         if ($LASTEXITCODE -ne 0) { Write-Host "Compilation failed"; exit 1 }
         writer
         & ".\$filename.exe"


### PR DESCRIPTION
## Summary
This PR fixes a build issue where `run.ps1` would fail on systems with GCC versions older than 13.

## Description
The script previously hardcoded the `-std=c++23` flag. Many standard Windows environments (like MinGW) default to GCC 11 or 12, which do not recognize this flag, resulting in the error: `unrecognized command line option '-std=c++23'`.

I have updated the build command to use a stable standard (C++17/20) that is supported by a wider range of compilers.

## Related Issue
Closes #3

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- Tested locally on a system with GCC 11.2.0.
- Verified that `.cpp` files now compile and run without the flag error.